### PR TITLE
add an additional data download method

### DIFF
--- a/notebooks/mpas-jedi.ipynb
+++ b/notebooks/mpas-jedi.ipynb
@@ -102,7 +102,6 @@
     "# hv.extension(\"bokeh\")\n",
     "# hv.extension(\"matplotlib\")\n",
     "\n",
-    "\n",
     "# common border lines\n",
     "coast_lines = gf.coastline(projection=ccrs.PlateCarree(), line_width=1, scale=\"50m\")\n",
     "state_lines = gf.states(projection=ccrs.PlateCarree(), line_width=1, line_color='gray', scale=\"50m\")"
@@ -224,7 +223,61 @@
    "metadata": {},
    "source": [
     "## Load MPAS data\n",
-    "Depending on the network, the data loading process may take a few minutes"
+    "Depending on the network, the data loading process may take a few minutes.    \n",
+    "\n",
+    "There are two ways to load MPAS data:\n",
+    "- 1. Download all example data from JetStream2 to local and them load them locally. This approach allows you to download the data once and reuse it in notebooks.\n",
+    "- 2. Access the JetStream2 S3 objects on demand. In this case, each notebook (incluidng restarting a notebook) will download the required data as needed, which may lead to repeated downloads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3848e8f-c836-44ed-ad1b-8f4d63e30bd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_load_method = 1  # or 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9aded3cd-525e-40eb-b722-c958c25f544a",
+   "metadata": {},
+   "source": [
+    "### Download all example data to your local disk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecc1a789-c3a8-4a0d-b9ff-6527ec561039",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# This cell only needs to run once in a machine and can be converted to a MarkDown cell before publishing the cookbook\n",
+    "\n",
+    "if data_load_method == 1:\n",
+    "    jetstream_url = 'https://js2.jetstream-cloud.org:8001/'\n",
+    "    fs = s3fs.S3FileSystem(anon=True, asynchronous=False,client_kwargs=dict(endpoint_url=jetstream_url))\n",
+    "    conus12_path = 's3://pythia/mpas/conus12km'\n",
+    "    local_dir=\"/tmp\"\n",
+    "    fs.get(conus12_path, local_dir, recursive=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec7c7316-b811-444c-a6b0-37031c90e9eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# path to the MPAS data\n",
+    "if data_load_method == 1:\n",
+    "    grid_file = local_dir + \"/conus12km/conus12km.invariant.nc_L60_GFS\"\n",
+    "    ana_file = local_dir + \"/conus12km/bkg/mpasout.2024-05-06_01.00.00.nc\"\n",
+    "    bkg_file = local_dir + \"/conus12km/ana/mpasout.2024-05-06_01.00.00.nc\""
    ]
   },
   {
@@ -232,7 +285,7 @@
    "id": "d77d663d-79a7-45b1-9ff3-8752f6853f3b",
    "metadata": {},
    "source": [
-    "### Data paths to the JetStream2 and S3 objects"
+    "### access JetStream2 and S3 objects on demand  "
    ]
   },
   {
@@ -243,18 +296,21 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "\n",
-    "jetstream_url = 'https://js2.jetstream-cloud.org:8001/'\n",
-    "fs = s3fs.S3FileSystem(anon=True, asynchronous=False,client_kwargs=dict(endpoint_url=jetstream_url))\n",
-    "conus12_path = 's3://pythia/mpas/conus12km'\n",
-    "\n",
-    "grid_url=f\"{conus12_path}/conus12km.invariant.nc_L60_GFS\"\n",
-    "bkg_url=f\"{conus12_path}/bkg/mpasout.2024-05-06_01.00.00.nc\"\n",
-    "ana_url=f\"{conus12_path}/ana/mpasout.2024-05-06_01.00.00.nc\"\n",
-    "\n",
-    "grid_file = fs.open(grid_url)\n",
-    "ana_file = fs.open(ana_url)\n",
-    "bkg_file = fs.open(bkg_url)"
+    "## **!! skip this section if data has been downloaded to local in the above !!**\n",
+    "if data_load_method == 2:\n",
+    "    jetstream_url = 'https://js2.jetstream-cloud.org:8001/'\n",
+    "    fs = s3fs.S3FileSystem(anon=True, asynchronous=False,client_kwargs=dict(endpoint_url=jetstream_url))\n",
+    "    conus12_path = 's3://pythia/mpas/conus12km'\n",
+    "    \n",
+    "    grid_url=f\"{conus12_path}/conus12km.invariant.nc_L60_GFS\"\n",
+    "    bkg_url=f\"{conus12_path}/bkg/mpasout.2024-05-06_01.00.00.nc\"\n",
+    "    ana_url=f\"{conus12_path}/ana/mpasout.2024-05-06_01.00.00.nc\"\n",
+    "    \n",
+    "    grid_file = fs.open(grid_url)\n",
+    "    ana_file = fs.open(ana_url)\n",
+    "    bkg_file = fs.open(bkg_url)\n",
+    "else:\n",
+    "    print(\"No action here, as example data has been downloaded to local in the above\")"
    ]
   },
   {
@@ -273,7 +329,6 @@
    "outputs": [],
    "source": [
     "%%time \n",
-    "\n",
     "uxds_a = ux.open_dataset(grid_file, ana_file)\n",
     "uxds_b = ux.open_dataset(grid_file, bkg_file)"
    ]
@@ -354,7 +409,7 @@
    "source": [
     "%%time\n",
     "\n",
-    "plot = hslice_contour(uxvar.isel(Time=0, nVertLevels=i_lev), title=f'Contour plot for potential temperature over a region (lev={i_lev}') #, symmetric_cmap=True)\n",
+    "plot = hslice_contour(uxvar.isel(Time=0, nVertLevels=i_lev), title=f'Contour plot for potential temperature over a region: lev={i_lev}') #, symmetric_cmap=True)\n",
     "plot * coast_lines * state_lines"
    ]
   },


### PR DESCRIPTION
Now we have two methods to download/load MPAS data:

- Download all example data from JetStream2 to local and them load them locally. This approach allows you to download the data once in a machine and reuse it in notebooks.
- Access the JetStream2 S3 objects on demand. In this case, each notebook (including restarting a notebook) will download the required data as needed, which may lead to repeated downloads.

Users set `data_load_method = 1  # or 2` before loading MPAS data