### PR TITLE
update notebooks/mpas-basic.ipynb to allow different data retrieval methods

### DIFF
--- a/notebooks/mpas-basic.ipynb
+++ b/notebooks/mpas-basic.ipynb
@@ -155,41 +155,102 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6fdf6ee5-3639-4d57-894f-6cd047f7a2ce",
+   "id": "9f829136-849e-4272-a13f-2a7071346939",
    "metadata": {},
    "source": [
-    "## Downloading the MPAS data"
+    "## Retrieve/load  MPAS/JEDI data\n",
+    "The example MPAS/JEDI data are stored at [jetstream2](https://par.nsf.gov/biblio/10296117-jetstream2-accelerating-cloud-computing-via-jetstream). We need to retreive those data first.   \n",
+    "There are two ways to retrieve MPAS data:\n",
+    "- 1. Download all example data from JetStream2 to local and them load them locally. This approach allows downloading the data once per machine and reuse it in notebooks.\n",
+    "- 2. Stream the JetStream2 S3 objects on demand. In this case, each notebook (including restarting a notebook) will retrieve the required data separately as needed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03124b28-8ea3-4c7b-91c2-a9f2919f3021",
+   "id": "14838043-77b7-4b66-9c4e-1e69f6b9047c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "jetstream_url = 'https://js2.jetstream-cloud.org:8001/'\n",
-    "fs = s3fs.S3FileSystem(anon=True, asynchronous=False,client_kwargs=dict(endpoint_url=jetstream_url))\n",
-    "conus12_path = 's3://pythia/mpas/conus12km'\n",
-    "\n",
-    "# Data paths to the JetStream2 and S3 objects\n",
-    "grid_url=f\"{conus12_path}/conus12km.invariant.nc_L60_GFS\"\n",
-    "bkg_url=f\"{conus12_path}/bkg/mpasout.2024-05-06_01.00.00.nc\"\n",
-    "ana_url=f\"{conus12_path}/ana/mpasout.2024-05-06_01.00.00.nc\"\n",
-    "\n",
-    "grid_file = fs.open(grid_url)\n",
-    "ana_file = fs.open(ana_url)\n",
-    "bkg_file = fs.open(bkg_url)"
+    "# choose the data_load_method, check the above cell for details. Default to method 1, i.e. download once and reuse it in multiple notebooks\n",
+    "data_load_method = 1  # or 2"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "21553ae5-4686-4f12-8fa8-e31d359f2156",
+   "id": "78e39945-5f20-4123-b5fd-f57726fc15a3",
    "metadata": {},
    "source": [
-    "### Loading the data into UXarray datasets\n",
+    "### Method 1: Download all example data once and reuse it in mulptile notebooks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee7b7d9f-8c00-4329-97b9-7c1e87f71042",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "local_dir=\"/tmp\"\n",
     "\n",
-    "We use the UXarray data structures for working with the data. This package supports data defined over unstructured grid and provides utilities for modifying and visualizing it. The available fucntionality are discussed in `UxDataset` [documentation](https://uxarray.readthedocs.io/en/latest/generated/uxarray.UxDataset.html#uxarray.UxDataset)."
+    "if data_load_method == 1 and not os.path.exists(local_dir + \"/conus12km/bkg/mpasout.2024-05-06_01.00.00.nc\"):\n",
+    "    jetstream_url = 'https://js2.jetstream-cloud.org:8001/'\n",
+    "    fs = s3fs.S3FileSystem(anon=True, asynchronous=False,client_kwargs=dict(endpoint_url=jetstream_url))\n",
+    "    conus12_path = 's3://pythia/mpas/conus12km'\n",
+    "    fs.get(conus12_path, local_dir, recursive=True)\n",
+    "    print(\"Data downloading completed\")\n",
+    "else:\n",
+    "    print(\"Skip..., either data is available in local or data_load_method is NOT 1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dffde994-d1ce-4309-95e8-1f1da25315e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set file path\n",
+    "if data_load_method == 1:\n",
+    "    grid_file = local_dir + \"/conus12km/conus12km.invariant.nc_L60_GFS\"\n",
+    "    ana_file = local_dir + \"/conus12km/bkg/mpasout.2024-05-06_01.00.00.nc\"\n",
+    "    bkg_file = local_dir + \"/conus12km/ana/mpasout.2024-05-06_01.00.00.nc\"\n",
+    "    # jdiag_file = local_dir + \"/conus12km/jdiag_aircar_t133.nc\"  #q133.nc or uv233.nc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c78c221-d5ec-4615-9e79-5d04ab6da936",
+   "metadata": {},
+   "source": [
+    "### Method 2: Stream the JetStream2 S3 objects on demand"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75bd8310-f6f1-4e4d-9cc2-c1f715c6e6cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "if data_load_method == 2:\n",
+    "    jetstream_url = 'https://js2.jetstream-cloud.org:8001/'\n",
+    "    fs = s3fs.S3FileSystem(anon=True, asynchronous=False,client_kwargs=dict(endpoint_url=jetstream_url))\n",
+    "    conus12_path = 's3://pythia/mpas/conus12km'\n",
+    "    \n",
+    "    grid_url=f\"{conus12_path}/conus12km.invariant.nc_L60_GFS\"\n",
+    "    bkg_url=f\"{conus12_path}/bkg/mpasout.2024-05-06_01.00.00.nc\"\n",
+    "    ana_url=f\"{conus12_path}/ana/mpasout.2024-05-06_01.00.00.nc\"\n",
+    "    # jdiag_url=f\"{conus12_path}/jdiag_aircar_t133.nc\"\n",
+    "    \n",
+    "    grid_file = fs.open(grid_url)\n",
+    "    ana_file = fs.open(ana_url)\n",
+    "    bkg_file = fs.open(bkg_url)\n",
+    "    # jdiag_file = fs.open(jdiag_url)\n",
+    "else:\n",
+    "    print(\"Skip..., data_load_method is NOT 2\")"
    ]
   },
   {
@@ -200,6 +261,16 @@
     ":::{warning}\n",
     "Depending on the network conditions, loading the data can take a few minutes.\n",
     ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21553ae5-4686-4f12-8fa8-e31d359f2156",
+   "metadata": {},
+   "source": [
+    "### Loading the data into UXarray datasets\n",
+    "\n",
+    "We use the UXarray data structures for working with the data. This package supports data defined over unstructured grid and provides utilities for modifying and visualizing it. The available fucntionality are discussed in [`UxDataset` documentation](https://uxarray.readthedocs.io/en/latest/generated/uxarray.UxDataset.html#uxarray.UxDataset)."
    ]
   },
   {


### PR DESCRIPTION
It is helpful to allow two different data retrieval methods: 1. download explicitly to local and then reuse it in multiple notebooks; 2. stream from jetstream2 on-demand in each notebook separately.

Both methods work for publishing.
The first method helps users when they work on their own machine.