### PR TITLE
Add Cook-off 2025 event to gallery info

### DIFF
--- a/_gallery_info.yml
+++ b/_gallery_info.yml
@@ -13,3 +13,5 @@ tags:
     - seaborn
     - xarray
     - NetCDF4
+  events:
+    - Cook-off 2025


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR just adds a gallery tag "Cook-off 2025" which we are using to identify Cookbooks that were originally developed at one of our hackathon events.