### PR TITLE
[FIX] mpas advanced - zonal mean plot

### DIFF
--- a/notebooks/mpas-advanced.ipynb
+++ b/notebooks/mpas-advanced.ipynb
@@ -887,7 +887,7 @@
     "        colorbar=True,colorbar_position='left'\n",
     "            )* coast_lines * state_lines\n",
     "    \n",
-    "    + zonal_mean_uxvar.plot.line(\n",
+    "    + zonal_mean_uxvar.hvplot.line(\n",
     "        x=\"theta_zonal_mean\",y=\"latitudes\",\n",
     "        height=250,width=150,\n",
     "        ylabel=\"\",\n",
@@ -895,12 +895,10 @@
     "        grid=True,\n",
     "        )\n",
     "    \n",
-    "    ).opts(\n",
+    ").opts(\n",
     "    title=\"Combined Raster and Zonal Average Plot\",\n",
     "    shared_axes=True,\n",
-    "      )\n",
-    "\n",
-    "\n"
+    "      )"
    ]
   },
   {
@@ -966,7 +964,7 @@
     "        colorbar=True,colorbar_position='left'\n",
     "            )* coast_lines * state_lines\n",
     "    \n",
-    "    + zonal_mean_uxvar.plot.line(\n",
+    "    + zonal_mean_uxvar.hvplot.line(\n",
     "        x=\"theta_zonal_mean\",\n",
     "        y=\"latitudes\",\n",
     "\n",


### PR DESCRIPTION
Fixes issue #70.

The zonal mean plot was crashing. The provided kwargs correspond clearly with zonal_mean_uxvar.hvplot, but there was a typo, the method actually being called is zonal_mean_uxvar.plot.

The code in the subsequent plotting cell also crashed locally for me. Changing to .hvplot instead of .plot seems to fix it.

